### PR TITLE
PdUcDVtQ | MS | Adding LU decomposition info + removed methods as per card

### DIFF
--- a/Matrix.cpp
+++ b/Matrix.cpp
@@ -1,19 +1,25 @@
 #include "Matrix.hpp"
 #include <iostream>
 #include <math.h>
+#include <assert.h>
 
 Matrix4::Matrix4(): matrix() 
 {
-    for (int i = 0; i < 4; i++) 
-    {
-        for (int j = 0; j < 4; j++) 
-        {
-            this->matrix[i][j] = 0.f;
-        }
-    }
     this->matrix[0][0] = 1.f;
+    this->matrix[0][1] = 0.f;
+    this->matrix[0][2] = 0.f;
+    this->matrix[0][3] = 0.f;
+    this->matrix[1][0] = 0.f;
     this->matrix[1][1] = 1.f;
+    this->matrix[1][2] = 0.f;
+    this->matrix[1][3] = 0.f;
+    this->matrix[2][0] = 0.f;
+    this->matrix[2][1] = 0.f;
     this->matrix[2][2] = 1.f;
+    this->matrix[2][3] = 0.f;
+    this->matrix[3][0] = 0.f;
+    this->matrix[3][1] = 0.f;
+    this->matrix[3][2] = 0.f;
     this->matrix[3][3] = 1.f;
 }
 
@@ -25,6 +31,11 @@ Matrix4::Matrix4(std::array<std::array<float, 4>, 4> matrix): matrix(matrix)
 Matrix4::~Matrix4() 
 {
 
+}
+
+void Matrix4::set(int row, int col, float value)
+{
+    this->matrix[row][col] = value;
 }
 
 float Matrix4::get(int row, int col) 
@@ -167,11 +178,6 @@ Matrix4 Matrix4::gluInverse()
     return Matrix4(result);
 }
 
-Matrix4 Matrix4::ludInverse() 
-{
-    return Matrix4();
-}
-
 Matrix4 Matrix4::transpose() 
 {
     std::array<std::array<float, 4>, 4> result;
@@ -221,6 +227,7 @@ Matrix4 Solver::solve(Matrix4& inputMatrix)
         {
             Solver::swap(col, maxRow, augmentedMatrix);
         }
+        assert(augmentedMatrix[col][col] != 0.f);
         Solver::scale(col, 1.f/augmentedMatrix[col][col], augmentedMatrix);
         for (int i = 0; i < 4; i++)
         {

--- a/Matrix.hpp
+++ b/Matrix.hpp
@@ -11,6 +11,7 @@ class Matrix4
         Matrix4(std::array<std::array<float, 4>, 4> matrix);
         ~Matrix4();
 
+        void set(int row, int col, float value);
         float get(int row, int col);
 
         Matrix4 operator+(const Matrix4& other);
@@ -22,7 +23,6 @@ class Matrix4
         Matrix4 inverse();
         Matrix4 gaussJordanInverse();
         Matrix4 gluInverse();
-        Matrix4 ludInverse();
         Matrix4 transpose();
 
         // util

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@
 - [Quaternions 3](http://graphics.stanford.edu/courses/cs348a-17-winter/Papers/quaternion.pdf)
 - [Quaternions 4](https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/)
 - [Quaternions 5](https://www.3dgep.com/understanding-quaternions/)
+- [General Matrix Knowledge] - any linear algebra book
+- [Matrix Inversion - Gauss Jordan](https://en.wikipedia.org/wiki/Gaussian_elimination#Pseudocode)
+- [Matrix Inversion - GLU implementation](https://stackoverflow.com/questions/1148309/inverting-a-4x4-matrix)
+- Node that the below was not actually implemented as from what i found LU decomposition (crout/doolittle) does not work in all cases.
+    - [Matrix Inversion - LU decomposition 1](https://en.wikipedia.org/wiki/LU_decomposition)
+    - [Matrix Inversion - LU decomposition 2](https://www.cl.cam.ac.uk/teaching/1314/NumMethods/supporting/mcmaster-kiruba-ludecomp.pdf)
+    - [Matrix Inversion - LU decomposition 3](https://www.youtube.com/watch?v=rhNKncraJMk)
+    - [Matrix Inversion - LU decomposition 4](http://www.mymathlib.com/matrices/linearsystems/doolittle.html)
+    - [Matrix Inversion - LU decomposition calc 1](https://www.atozmath.com/MatrixEv.aspx?q=doolit&q1=1%2c2%2c3%2c4%3b5%2c6%2c7%2c8%3b9%2c1%2c3%2c3%3b4%2c5%2c6%2c6%60doolit%60&dm=D&dp=8&do=1#PrevPart) - shows different methods
+    - [Matrix Inversion - LU decomposition calc 2](https://keisan.casio.com/exec/system/15076953047019#) - i think this one uses gauss elimination variant instead of crout/doolittle
 
 ### Drawing a line
 


### PR DESCRIPTION
Added info on LU decomposition but after spending some time trying to implement doolittle's algorithm i found that it does not work on all matrices so i decided to not include any implementation. I saw three methods from my googling (Doolittle/Crout/Gaussian elimination variant) and only the gaussian worked for the matrix below but we already have gaussian elimination no point in including it again.

```
 1  1  1 -1
 1  1 -1  1
 1 -1  1  1
-1  1  1  1
```

Card: https://trello.com/c/PdUcDVtQ/10-transformation-matrices