### PR TITLE
#11 | Depth buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@
 - [Software Renderer by Ssloy](https://github.com/ssloy/tinyrenderer)
 - [Learn OpenGL](https://learnopengl.com/)
 
+### Books
+
+- [Mathematics for 3D Game Programming and Computer Graphics, Third Edition](https://www.amazon.com/Mathematics-Programming-Computer-Graphics-Third/dp/1435458869)
+- [Fundamentals of Computer Graphics](https://www.amazon.com/Fundamentals-Computer-Graphics-Peter-Shirley/dp/1568814690)
+- [Free Linear Algebra Book](https://joshua.smcvt.edu/linearalgebra/book.pdf)
+
 ### Math
 
-- General Matrix Knowledge - any linear algebra book
 - [Change of Basis vs Linear Transformation](http://boris-belousov.net/2016/05/31/change-of-basis/)
 - [Quaternions 1](https://en.wikipedia.org/wiki/Quaternion)
 - [Quaternions 2](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Proof_of_the_quaternion_rotation_identity)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Software Renderer by Zauonlok](https://github.com/zauonlok/renderer)
 - [Software Renderer by Ssloy](https://github.com/ssloy/tinyrenderer)
 - [Learn OpenGL](https://learnopengl.com/)
+- [OpenGL 4.4 - Spec](https://www.khronos.org/registry/OpenGL/specs/gl/glspec44.core.pdf)
 
 ### Books
 
@@ -81,3 +82,9 @@
 - [Perspective projection derivation (OpenGL)](https://www.scratchapixel.com/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/opengl-perspective-projection-matrix)
 - [Free camera](https://learnopengl.com/Getting-started/Camera)
 - [Euler to direction vector (explains the LearnOpenGL article formula)](https://math.stackexchange.com/questions/1791209/euler-angle-to-direction-vector-which-is-right)
+
+### Z-Buffer
+
+- [Scratchapixel article](https://www.scratchapixel.com/lessons/3d-basic-rendering/rasterization-practical-implementation/perspective-correct-interpolation-vertex-attributes)
+- [Perspective correct interpolation](https://stackoverflow.com/questions/24441631/how-exactly-does-opengl-do-perspectively-correct-linear-interpolation)
+- OpenGL Spec linked in the general references also has the perspective correct formula

--- a/src/Buffer.hpp
+++ b/src/Buffer.hpp
@@ -37,11 +37,11 @@ class Buffer {
             return this->buffer.data();
         }
 
-        void clear()
+        void clear(T value = (T)0)
         {
             for (int i = 0; i < this->width * this->height; i++)
             {
-                this->buffer[i] = 0;
+                this->buffer[i] = value;
             }
         }
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -18,7 +18,7 @@ Camera::~Camera()
 
 }
 
-void Camera::update(CameraInput& input)
+void Camera::update(FrameInput& input)
 {
     float speed = 0.5f;
     if (input.forward)
@@ -107,17 +107,4 @@ Matrix4 Camera::getProjectionMatrix()
     result.set(3, 2, -1.f);
     result.set(3, 3, 0.f);
     return result;
-}
-
-
-// Camera Input
-
-void CameraInput::clear()
-{
-    this->forward = false;
-    this->left = false;
-    this->backward = false;
-    this->right = false;
-    this->relativeX = (int32_t)0;
-    this->relativeY = (int32_t)0;
 }

--- a/src/Camera.hpp
+++ b/src/Camera.hpp
@@ -4,20 +4,7 @@
 #include "Vector.hpp"
 #include "Frustum.hpp"
 #include "EulerRotation.hpp"
-
-class CameraInput
-{
-    public:
-
-        void clear();
-        
-        bool forward;
-        bool left;
-        bool backward;
-        bool right;
-        int32_t relativeX;
-        int32_t relativeY;
-};
+#include "FrameInput.hpp"
 
 class Camera
 {
@@ -26,7 +13,7 @@ class Camera
         Camera(Vector4f position, float fovX, float aspectRatio, float near, float far);
         ~Camera();
 
-        void update(CameraInput& input);
+        void update(FrameInput& input);
         Matrix4 getViewMatrix();
         Matrix4 getProjectionMatrix();
 

--- a/src/FrameInput.cpp
+++ b/src/FrameInput.cpp
@@ -1,0 +1,12 @@
+#include "FrameInput.hpp"
+
+void FrameInput::clear()
+{
+    this->forward = false;
+    this->left = false;
+    this->backward = false;
+    this->right = false;
+    this->relativeX = 0;
+    this->relativeY = 0;
+    this->switchRasterMethod = false;
+}

--- a/src/FrameInput.hpp
+++ b/src/FrameInput.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+class FrameInput
+{
+    public:
+
+        void clear();
+            
+        bool forward;
+        bool left;
+        bool backward;
+        bool right;
+        int32_t relativeX;
+        int32_t relativeY;
+
+        bool switchRasterMethod;
+
+    private:
+};

--- a/src/Rasterizer.hpp
+++ b/src/Rasterizer.hpp
@@ -21,12 +21,14 @@ class Rasterizer
         static void drawLine(std::array<Vector4f, 2> vertices, 
                              std::array<uint8_t, 6> colors,
                              Shader* shader, 
-                             FrameBuffer* frameBuffer);
+                             FrameBuffer* frameBuffer,
+                             DepthBuffer* depthBuffer);
         // TODO: https://trello.com/c/Qu1r6CSK/9-see-if-there-is-a-perf-gain-if-we-use-ref-to-stdarray-vs-copy-of-stdarray-in-the-rasterizer
         static void drawTriangle(std::array<Vector4f, 3> vertices,
                                  std::array<uint8_t, 9> colors,
                                  Shader* shader, 
                                  FrameBuffer* frameBuffer, 
+                                 DepthBuffer* depthBuffer,
                                  RasterMethod method);
 
         static const SDL_PixelFormat* PIXEL_FORMAT;
@@ -37,23 +39,27 @@ class Rasterizer
         static void drawTriangleFlat(std::array<Vector4f, 3> vertices, 
                                      std::array<uint8_t, 9> colors,
                                      Shader* shader, 
-                                     FrameBuffer* frameBuffer);
+                                     FrameBuffer* frameBuffer,
+                                     DepthBuffer* depthBuffer);
         
         static void drawTriangleFlatBottom(std::array<Vector4f, 3> vertices, 
                                            std::array<uint8_t, 9> colors, 
                                            Shader* shader, 
-                                           FrameBuffer* frameBuffer);
+                                           FrameBuffer* frameBuffer,
+                                           DepthBuffer* depthBuffer);
 
         static void drawTriangleFlatTop(std::array<Vector4f, 3> vertices, 
                                         std::array<uint8_t, 9> colors, 
                                         Shader* shader, 
-                                        FrameBuffer* frameBuffer);
+                                        FrameBuffer* frameBuffer,
+                                        DepthBuffer* depthBuffer);
 
         // DrawTriangleAABB - Uses the edge method + bounding box
         static void drawTriangleAABB(std::array<Vector4f, 3> vertices, 
                                      std::array<uint8_t, 9> colors, 
                                      Shader* shader, 
-                                     FrameBuffer* frameBuffer);
+                                     FrameBuffer* frameBuffer,
+                                     DepthBuffer* depthBuffer);
 
         static int edgeCheck(int x0, int y0, int x1, int y1, int x2, int y2);
 };

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -2,7 +2,7 @@
 
 #include <SDL2/SDL.h>
 
-Scene::Scene(int width, int height): models(), input()
+Scene::Scene(int width, int height): models()
 {
     std::unique_ptr<Model> model = std::make_unique<Model>(0.f, 0.f, 0.f, Vector4f(10.f, 0.f, 10.f, 1.f));
     this->models.push_back(std::move(model));
@@ -15,7 +15,7 @@ Scene::~Scene()
 
 }
 
-bool Scene::handleInput()
+bool Scene::handleInput(FrameInput& input)
 {
     SDL_Event event;
     while (SDL_PollEvent(&event)) 
@@ -24,38 +24,42 @@ bool Scene::handleInput()
         {
             return false;
         }
+        if (event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_E)
+        {
+            input.switchRasterMethod = true;
+        }
         if (event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_W)
         {
-            this->input.forward = true;
+            input.forward = true;
         }
         if (event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_A)
         {
-            this->input.left = true;
+            input.left = true;
         }
         if (event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_S)
         {
-            this->input.backward = true;
+            input.backward = true;
         }
         if (event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_D)
         {
-            this->input.right = true;
+            input.right = true;
         }
         if (event.type == SDL_MOUSEMOTION)
         {
-            this->input.relativeX = event.motion.xrel;
-            this->input.relativeY = event.motion.yrel;
+            input.relativeX = event.motion.xrel;
+            input.relativeY = event.motion.yrel;
         }
     }
     return true;
 }
 
-void Scene::update(float deltaTime) 
+void Scene::update(float deltaTime, FrameInput& input) 
 {
     for (int i = 0; i < this->models.size(); i++) 
     {
         this->models[i]->update(deltaTime);
     }
-    this->camera->update(this->input);
+    this->camera->update(input);
 }
 
 const std::vector<std::unique_ptr<Model>>& Scene::getModels()
@@ -66,9 +70,4 @@ const std::vector<std::unique_ptr<Model>>& Scene::getModels()
 Camera* Scene::getCamera()
 {
     return this->camera.get();
-}
-
-void Scene::clearInput()
-{
-    this->input.clear();
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -4,7 +4,7 @@
 
 Scene::Scene(int width, int height): models()
 {
-    std::unique_ptr<Model> model = std::make_unique<Model>(0.f, 0.f, 0.f, Vector4f(10.f, 0.f, 10.f, 1.f));
+    std::unique_ptr<Model> model = std::make_unique<Model>(0.f, 0.f, 0.f, Vector4f(0.f, 0.f, 0.f, 1.f));
     this->models.push_back(std::move(model));
     this->camera = std::make_unique<Camera>(Vector4f(-7.16f, -31.f, 29.f, 1.f), 1.5707f, 
                                             (float)width/(float)height, 10.f, 100.f);

--- a/src/Scene.hpp
+++ b/src/Scene.hpp
@@ -5,6 +5,7 @@
 
 #include "Model.hpp"
 #include "Camera.hpp"
+#include "FrameInput.hpp"
 
 class Scene 
 {
@@ -13,9 +14,8 @@ class Scene
         // Methods
         Scene(int width, int height);
         ~Scene();
-        bool handleInput();
-        void clearInput();
-        void update(float deltaTime);
+        bool handleInput(FrameInput& input);
+        void update(float deltaTime, FrameInput& input);
         const std::vector<std::unique_ptr<Model>>& getModels();
         Camera* getCamera();
 
@@ -24,6 +24,5 @@ class Scene
         // Data
         std::vector<float>                  lights;
         std::unique_ptr<Camera>             camera;
-        CameraInput                         input;
         std::vector<std::unique_ptr<Model>> models;
 };

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -4,7 +4,7 @@ BasicShader::BasicShader(Model* model, Camera* camera): world(model->getWorldMat
                                                         view(camera->getViewMatrix()),
                                                         projection(camera->getProjectionMatrix())
 {
-    this->modelViewProj = this->projection * this->view * this->world;
+    this->modelViewProjection = this->projection * this->view * this->world;
 }
 
 BasicShader::~BasicShader() 
@@ -14,8 +14,7 @@ BasicShader::~BasicShader()
 
 Vector4f BasicShader::processVertex(Vector4f& vertex)
 {
-    Vector4f result = this->modelViewProj * vertex;
-    return result;
+    return this->modelViewProjection * vertex;
 }
 
 void BasicShader::processFragment() 

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -26,7 +26,7 @@ class BasicShader: public Shader
     
     private:
 
-        Matrix4 modelViewProj;
+        Matrix4 modelViewProjection;
         Matrix4 world;
         Matrix4 view;
         Matrix4 projection;

--- a/src/SoftwareRenderer.hpp
+++ b/src/SoftwareRenderer.hpp
@@ -21,6 +21,7 @@ class SoftwareRenderer
         SoftwareRenderer(int width, int height, ShaderType shaderType);
         ~SoftwareRenderer();
         void run();
+        void update();
         void draw();
         void drawModel(Model* model);
         void clear();
@@ -36,4 +37,5 @@ class SoftwareRenderer
         RasterMethod                    rasterMethod;
         std::unique_ptr<Scene>          scene;
         ShaderType                      shaderType;
+        FrameInput                      input;
 };

--- a/src/Vector.hpp
+++ b/src/Vector.hpp
@@ -48,12 +48,12 @@ class Vector4
         
         Vector4 operator*(T value) const 
         {
-            return Vector4<T>(this->x * value, this->y * value, this->z * value, 1.f);
+            return Vector4<T>(this->x * value, this->y * value, this->z * value, this->w);
         }
 
         Vector4 operator/(T value) const 
         {
-            return Vector4<T>(this->x / value, this->y / value, this->z / value, 1.f);
+            return Vector4<T>(this->x / value, this->y / value, this->z / value, this->w);
         }
 
         float dot(const Vector4<T>& other) const

--- a/src/test/testCamera.cpp
+++ b/src/test/testCamera.cpp
@@ -14,7 +14,6 @@ void testCameraViewMatrix()
         {0, 0, 0, 1}
     }};
     Matrix4 expected(expectedArray);
-    CameraInput input;
     Camera camera(Vector4f(1.f, 1.f, 1.f, 1.f), 3.14f, 1.33f, 10.f, 100.f);
     Matrix4 actual = camera.getViewMatrix();
     ASSERT_MATRIX4(actual, expected);

--- a/src/test/testRasterizer.cpp
+++ b/src/test/testRasterizer.cpp
@@ -13,6 +13,7 @@ void testDrawLineStraight()
     int height = 100;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -21,7 +22,7 @@ void testDrawLineStraight()
         Vector4f(75.f, 50.f, 20.f, 1.f),
     };
     std::array<uint8_t, 6> colors{(uint8_t)123, (uint8_t)0, (uint8_t)255, (uint8_t)123, (uint8_t)0, (uint8_t)255};
-    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get());
+    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get(), depthBuffer.get());
     for (int i = 0; i < width; i++)
     {
         for (int j = 0; j < height; j++)
@@ -41,6 +42,7 @@ void testDrawLineStraight2()
     int height = 100;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -49,7 +51,7 @@ void testDrawLineStraight2()
         Vector4f(25.f, 50.f, 20.f, 1.f),
     };
     std::array<uint8_t, 6> colors{(uint8_t)123, (uint8_t)0, (uint8_t)255, (uint8_t)123, (uint8_t)0, (uint8_t)255};
-    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get());
+    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get(), depthBuffer.get());
     for (int i = 0; i < width; i++)
     {
         for (int j = 0; j < height; j++)
@@ -69,6 +71,7 @@ void testDrawLinePositiveSlope()
     int height = 10;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -77,7 +80,7 @@ void testDrawLinePositiveSlope()
         Vector4f(5.f, 3.f, 20.f, 1.f),
     };
     std::array<uint8_t, 6> colors{(uint8_t)123, (uint8_t)0, (uint8_t)255, (uint8_t)123, (uint8_t)0, (uint8_t)255};
-    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get());
+    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get(), depthBuffer.get());
     expected->set(1, 8, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 7, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(3, 6, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
@@ -93,6 +96,7 @@ void testDrawLineNegativeSlope()
     int height = 10;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -101,7 +105,7 @@ void testDrawLineNegativeSlope()
         Vector4f(1.f, 3.f, 20.f, 1.f),
     };
     std::array<uint8_t, 6> colors{(uint8_t)123, (uint8_t)0, (uint8_t)255, (uint8_t)123, (uint8_t)0, (uint8_t)255};
-    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get());
+    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get(), depthBuffer.get());
     expected->set(1, 3, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 4, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(3, 5, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
@@ -117,6 +121,7 @@ void testDrawLineSteep()
     int height = 10;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -125,7 +130,7 @@ void testDrawLineSteep()
         Vector4f(3.f, 8.f, 20.f, 1.f),
     };
     std::array<uint8_t, 6> colors{(uint8_t)123, (uint8_t)0, (uint8_t)255, (uint8_t)123, (uint8_t)0, (uint8_t)255};
-    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get());
+    Rasterizer::drawLine(vertices, colors, shader.get(), actual.get(), depthBuffer.get());
     expected->set(1, 1, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(1, 2, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 3, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
@@ -143,6 +148,7 @@ void testDrawTriangleAABB()
     int height = 10;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -156,7 +162,7 @@ void testDrawTriangleAABB()
         (uint8_t)123, (uint8_t)0, (uint8_t)255, 
         (uint8_t)123, (uint8_t)0, (uint8_t)255
     };
-    Rasterizer::drawTriangle(vertices, colors, shader.get(), actual.get(), RasterMethod::EDGE_AABB);
+    Rasterizer::drawTriangle(vertices, colors, shader.get(), actual.get(), depthBuffer.get(), RasterMethod::EDGE_AABB);
     expected->set(1, 4, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 4, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(3, 3, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
@@ -186,6 +192,7 @@ void testDrawTriangleFlat()
     int height = 10;
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
+    std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);
@@ -199,7 +206,7 @@ void testDrawTriangleFlat()
         (uint8_t)123, (uint8_t)0, (uint8_t)255, 
         (uint8_t)123, (uint8_t)0, (uint8_t)255
     };
-    Rasterizer::drawTriangle(vertices, colors, shader.get(), actual.get(), RasterMethod::FLAT_SPLIT);
+    Rasterizer::drawTriangle(vertices, colors, shader.get(), actual.get(), depthBuffer.get(), RasterMethod::FLAT_SPLIT);
     expected->set(1, 4, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 4, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));
     expected->set(2, 5, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, colors[0], colors[1], colors[2]));

--- a/src/test/testRasterizer.cpp
+++ b/src/test/testRasterizer.cpp
@@ -149,6 +149,10 @@ void testDrawTriangleAABB()
     std::unique_ptr<FrameBuffer> actual = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<FrameBuffer> expected = std::make_unique<FrameBuffer>(width, height);
     std::unique_ptr<DepthBuffer> depthBuffer = std::make_unique<DepthBuffer>(width, height);
+    // depth buffer check relies on the fact that we do perspective divide in the renderer
+    // that calls the drawTriangle method. To avoid problems the depth value passed below must be higher than
+    // the biggest z coordinate
+    depthBuffer->clear(30.f);
     Model model(2.456f, 3.23f, 5.55f, Vector4f(20.f, 20.f, 20.f, 1.f));
     Camera camera(Vector4f(), 1.f, 1.f, 1.f, 1.f);
     std::unique_ptr<BasicShader> shader = std::make_unique<BasicShader>(&model, &camera);


### PR DESCRIPTION
- Moved the `CameraInput` code into a new `FrameInput` class that will be used for all inputs.
- Added Z-Buffer that gets checked/updated when rasterizing a triangle.
    - As per the code, the implementation uses `z` instead of  `1/z` but it still seems to work. I think thats the case because the projected `z` coordinates are less then `1` and have been scaled uniformly