### PR TITLE
Moving Vector/Quaternion/Matrix to templated ASSERT_VALUE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CXX           	:= g++
 SRCDIR 			:= .
 OBJDIR			:= ./out
 EXECUTABLE    	:= renderer
-CXXFLAGS      	:= -std=c++14
+CXXFLAGS      	:= -std=c++17
 SRCFILES	 	:= $(shell find $(SRCDIR) -name "*.cpp")
 SRCNAMES		:= $(notdir $(SRCFILES))
 OBJFILES 	    := $(SRCNAMES:%.cpp=$(OBJDIR)/%.o)

--- a/src/Buffer.hpp
+++ b/src/Buffer.hpp
@@ -22,12 +22,12 @@ class Buffer {
             this->buffer[x + y * this->width] = value;
         }
 
-        T get(int x, int y) 
+        T get(int x, int y) const
         {
             return this->buffer[x + y * this->width];
         }
 
-        int size() 
+        int size() const
         {
             return this->width * this->height;
         }

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -38,12 +38,12 @@ void Matrix4::set(int row, int col, float value)
     this->matrix[row][col] = value;
 }
 
-float Matrix4::get(int row, int col) 
+float Matrix4::get(int row, int col) const
 {
     return this->matrix[row][col];
 }
 
-Matrix4 Matrix4::operator*(const Matrix4& other) 
+Matrix4 Matrix4::operator*(const Matrix4& other) const
 {
     std::array<std::array<float, 4>, 4> result;
     for (int i = 0; i < 4; i++) 
@@ -60,7 +60,7 @@ Matrix4 Matrix4::operator*(const Matrix4& other)
     return Matrix4(result);
 }
 
-Matrix4 Matrix4::operator*(float value) 
+Matrix4 Matrix4::operator*(float value) const
 {
     std::array<std::array<float, 4>, 4> result;
     for (int i = 0; i < 4; i++) 
@@ -73,7 +73,7 @@ Matrix4 Matrix4::operator*(float value)
     return Matrix4(result);
 }
 
-Matrix4 Matrix4::operator+(const Matrix4& other) 
+Matrix4 Matrix4::operator+(const Matrix4& other) const
 {
     std::array<std::array<float, 4>, 4> result;
     for (int i = 0; i < 4; i++) 
@@ -86,7 +86,7 @@ Matrix4 Matrix4::operator+(const Matrix4& other)
     return Matrix4(result);
 }
 
-Matrix4 Matrix4::operator-(const Matrix4& other) 
+Matrix4 Matrix4::operator-(const Matrix4& other) const
 {
     std::array<std::array<float, 4>, 4> result;
     for (int i = 0; i < 4; i++) 
@@ -99,7 +99,7 @@ Matrix4 Matrix4::operator-(const Matrix4& other)
     return Matrix4(result);
 }
 
-Vector4f Matrix4::operator*(const Vector4f& other) 
+Vector4f Matrix4::operator*(const Vector4f& other) const
 {
     float x, y, z, w;
     x = this->matrix[0][0] * other.x + \
@@ -119,6 +119,27 @@ Vector4f Matrix4::operator*(const Vector4f& other)
         this->matrix[3][2] * other.z + \
         this->matrix[3][3] * other.w;
     return Vector4f(x, y, z, w);
+}
+
+bool Matrix4::operator==(const Matrix4& other) const 
+{
+    bool isEqual = true;
+    for (int i = 0; i < 4; i++)
+    {
+        for (int j = 0; j < 4; j++)
+        {
+            if (fabs(this->matrix[i][j] - other.get(i, j)) > 0.0005f)
+            {
+                isEqual = false;
+            }
+        }
+    }
+    return isEqual;
+}
+
+bool Matrix4::operator!=(const Matrix4& other) const
+{
+    return !(this->operator==(other));
 }
 
 Matrix4 Matrix4::inverse() 
@@ -302,4 +323,18 @@ void Solver::add(int first,
     {
         augmentedMatrix[first][i] = augmentedMatrix[first][i] * firstScale + augmentedMatrix[second][i] * secondScale;
     }
+}
+
+std::ostream& operator<<(std::ostream& outputStream, const Matrix4& other)
+{
+    outputStream << "-- Matrix --" << std::endl;
+    for (int i = 0; i < 4; i++) 
+    {
+        for (int j = 0; j < 4; j++) 
+        {
+            outputStream << other.get(i, j) << ", ";
+        }
+        outputStream << std::endl;
+    }
+    return outputStream;
 }

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -12,13 +12,16 @@ class Matrix4
         ~Matrix4();
 
         void set(int row, int col, float value);
-        float get(int row, int col);
+        float get(int row, int col) const;
 
-        Matrix4 operator+(const Matrix4& other);
-        Matrix4 operator-(const Matrix4& other);
-        Matrix4 operator*(const Matrix4& other);
-        Vector4f operator*(const Vector4f& other);
-        Matrix4 operator*(float value);
+        Matrix4 operator+(const Matrix4& other) const;
+        Matrix4 operator-(const Matrix4& other) const;
+        Matrix4 operator*(const Matrix4& other) const;
+        Vector4f operator*(const Vector4f& other) const;
+        Matrix4 operator*(float value) const;
+        bool operator==(const Matrix4& other) const;
+        bool operator!=(const Matrix4& other) const;
+        friend std::ostream& operator<<(std::ostream& outputStream, const Matrix4& other);
 
         Matrix4 inverse();
         Matrix4 gaussJordanInverse();
@@ -32,6 +35,8 @@ class Matrix4
 
         std::array<std::array<float, 4>, 4> matrix;
 };
+
+std::ostream& operator<<(std::ostream& outputStream, const Matrix4& other);
 
 class Solver 
 {

--- a/src/Quaternion.cpp
+++ b/src/Quaternion.cpp
@@ -30,7 +30,7 @@ Quaternion::~Quaternion()
 
 }
 
-Quaternion Quaternion::operator*(const Quaternion& other) 
+Quaternion Quaternion::operator*(const Quaternion& other) const
 {
     // // https://en.wikipedia.org/wiki/Quaternion#Hamilton_product
     // float w = this->w * other.w - (this->x * other.x) - (this->y * other.y) - (this->z * other.z);
@@ -44,13 +44,30 @@ Quaternion Quaternion::operator*(const Quaternion& other)
     Vector4f v1{this->x, this->y, this->z, 1.f};
     Vector4f v2{other.x, other.y, other.z, 1.f};
     Vector4f v3 = v1.cross(v2) +  v2 * this->w + v1 * other.w;
-    float w = (this->w * other.w) - v1.dot(v2);
-    return Quaternion(w, v3.x, v3.y, v3.z);
+    float newW = (this->w * other.w) - v1.dot(v2);
+    return Quaternion(newW, v3.x, v3.y, v3.z);
 }
 
-Quaternion Quaternion::operator*(float value)
+Quaternion Quaternion::operator*(float value) const
 {
     return Quaternion(this->w * value, this->x * value, this->y * value, this->z * value);
+}
+
+bool Quaternion::operator==(const Quaternion& other) const
+{
+    if (fabs(this->w - other.w) > 0.0005f || \
+        fabs(this->x - other.x) > 0.0005f || \
+        fabs(this->y - other.y) > 0.0005f || \
+        fabs(this->z - other.z) > 0.0005f)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool Quaternion::operator!=(const Quaternion& other) const
+{
+    return !(this->operator==(other));
 }
 
 Quaternion Quaternion::conjugate() 
@@ -127,5 +144,11 @@ Matrix4 Quaternion::toMatrix()
 
 void Quaternion::print() 
 {
-    std::cout << "Quaternion (" << this->w << ", " << this->x << ", " << this->y << ", " << this->z << ")" << std::endl;
+    std::cout << "Quaternion(" << this->w << ", " << this->x << ", " << this->y << ", " << this->z << ")" << std::endl;
+}
+
+std::ostream& operator<<(std::ostream& outputStream, const Quaternion& other)
+{
+    outputStream << "Quaternion(" << other.w << ", " << other.x << ", " << other.y << ", " << other.z << ")";
+    return outputStream;
 }

--- a/src/Quaternion.hpp
+++ b/src/Quaternion.hpp
@@ -11,8 +11,11 @@ class Quaternion
         Quaternion(float w, float x, float y, float z);
         ~Quaternion();
 
-        Quaternion operator*(const Quaternion& other);
-        Quaternion operator*(float value);
+        Quaternion operator*(const Quaternion& other) const;
+        Quaternion operator*(float value) const;
+        bool operator==(const Quaternion& other) const;
+        bool operator!=(const Quaternion& other) const;
+        friend std::ostream& operator<<(std::ostream& outputStream, const Quaternion& other);
 
         Quaternion conjugate();
         Quaternion inverse();
@@ -32,3 +35,4 @@ class Quaternion
 };
 
 Quaternion makeQuat(float w, float x, float y, float z);
+std::ostream& operator<<(std::ostream& outputStream, const Quaternion& other);

--- a/src/Vector.hpp
+++ b/src/Vector.hpp
@@ -56,6 +56,19 @@ class Vector4
             return Vector4<T>(this->x / value, this->y / value, this->z / value, this->w);
         }
 
+        bool operator==(const Vector4<T>& other) const 
+        {
+            return this->x == other.x && this->y == other.y && this->z == other.z && this->w == other.w;
+        }
+
+        bool operator!=(const Vector4<T>& other) const 
+        {
+            return !(this->operator==(other));
+        }
+
+        template<typename U>
+        friend std::ostream& operator<<(std::ostream& outputStream, const Vector4<U>& other);
+
         float dot(const Vector4<T>& other) const
         {
             return this->x * other.x + this->y * other.y + this->z * other.z;
@@ -97,6 +110,13 @@ class Vector4
         T z;
         T w;
 };
+
+template<typename T>
+std::ostream& operator<<(std::ostream& outputStream, const Vector4<T>& other)
+{
+    outputStream << "Vector4(" << other.x << ", " << other.y << ", " << other.z << ", " << other.w << ")";
+    return outputStream;
+}
 
 typedef Vector4<float> Vector4f;
 typedef Vector4<int> Vector4i;

--- a/src/test/testCamera.cpp
+++ b/src/test/testCamera.cpp
@@ -16,7 +16,7 @@ void testCameraViewMatrix()
     Matrix4 expected(expectedArray);
     Camera camera(Vector4f(1.f, 1.f, 1.f, 1.f), 3.14f, 1.33f, 10.f, 100.f);
     Matrix4 actual = camera.getViewMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testCameraPerspectiveProjection()
@@ -38,7 +38,7 @@ void testCameraPerspectiveProjection()
     Matrix4 expected(expectedArray);
     Camera camera(Vector4f(1.f, 1.f, 1.f, 1.f), fovX, aspectRatio, near, far);
     Matrix4 actual = camera.getProjectionMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testCamera()

--- a/src/test/testMatrix.cpp
+++ b/src/test/testMatrix.cpp
@@ -13,7 +13,7 @@ void testMatrixInitPlain()
         {0, 0, 0, 1}
     }};
     Matrix4 actual;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixAddition() 
@@ -41,7 +41,7 @@ void testMatrixAddition()
     }};
     Matrix4 actual2{actualArray2};
     Matrix4 actual = actual1 + actual2;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixSubtraction() 
@@ -69,7 +69,7 @@ void testMatrixSubtraction()
     }};
     Matrix4 actual2{actualArray2};
     Matrix4 actual = actual1 - actual2;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixMatrixMultiplication() 
@@ -97,7 +97,7 @@ void testMatrixMatrixMultiplication()
     }};
     Matrix4 actual2{actualArray2};
     Matrix4 actual = actual1 * actual2;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixScalarMultiplication() 
@@ -116,7 +116,7 @@ void testMatrixScalarMultiplication()
     }};
     Matrix4 actual{actualArray};
     actual = actual * -1;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixScalarMultiplication2() 
@@ -135,7 +135,7 @@ void testMatrixScalarMultiplication2()
     }};
     Matrix4 actual{actualArray};
     actual = actual * 0.5f;
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixTranspose() 
@@ -154,7 +154,7 @@ void testMatrixTranspose()
     }};
     Matrix4 actual{actualArray};
     actual = actual.transpose();
-    ASSERT_MATRIX4(actual, Matrix4(expected));
+    ASSERT_VALUE(Matrix4, actual, Matrix4(expected));
 }
 
 void testMatrixVectorMultiplication() 
@@ -169,7 +169,7 @@ void testMatrixVectorMultiplication()
     }};
     Matrix4 inputMatrix{inputArray};
     Vector4f actual = inputMatrix * inputVector;
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testMatrixInverseGaussJordan() 
@@ -189,7 +189,7 @@ void testMatrixInverseGaussJordan()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gaussJordanInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrixInverseGaussJordan2() 
@@ -209,7 +209,7 @@ void testMatrixInverseGaussJordan2()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gaussJordanInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrixInverseGaussJordan3() 
@@ -229,7 +229,7 @@ void testMatrixInverseGaussJordan3()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gaussJordanInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrixInverseGLU() 
@@ -249,7 +249,7 @@ void testMatrixInverseGLU()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gluInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrixInverseGLU2() 
@@ -269,7 +269,7 @@ void testMatrixInverseGLU2()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gluInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrixInverseGLU3() 
@@ -289,7 +289,7 @@ void testMatrixInverseGLU3()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = actual.gluInverse();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testMatrix() {

--- a/src/test/testModel.cpp
+++ b/src/test/testModel.cpp
@@ -19,7 +19,7 @@ void testModelEulerRotation()
     Model model(2.456f, 3.23f, 5.55f, Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::EULER);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelQuaternionRotation()
@@ -39,7 +39,7 @@ void testModelQuaternionRotation()
                 Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::QUATERNION);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelAxisAngleRotation()
@@ -57,7 +57,7 @@ void testModelAxisAngleRotation()
                 Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::AXIS_ANGLE);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromEulerToQuaternion()
@@ -73,12 +73,12 @@ void testModelSwitchFromEulerToQuaternion()
     Model model(2.456f, 3.23f, 5.55f, Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::EULER);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to quat
     model.setRotationType(RotationType::QUATERNION);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::QUATERNION);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromEulerToAxisAngle()
@@ -94,12 +94,12 @@ void testModelSwitchFromEulerToAxisAngle()
     Model model(2.456f, 3.23f, 5.55f, Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::EULER);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to axisAngle
     model.setRotationType(RotationType::AXIS_ANGLE);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::AXIS_ANGLE);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromAxisAngleToEuler()
@@ -115,12 +115,12 @@ void testModelSwitchFromAxisAngleToEuler()
     Model model(3.80020f, Vector4f(0.16825f, -0.31551f, -0.93388f, 1.f), Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::AXIS_ANGLE);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to Euler
     model.setRotationType(RotationType::EULER);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::EULER);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromAxisAngleToQuaternion()
@@ -136,12 +136,12 @@ void testModelSwitchFromAxisAngleToQuaternion()
     Model model(3.80020f, Vector4f(0.16825f, -0.31551f, -0.93388f, 1.f), Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::AXIS_ANGLE);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to Quaternion
     model.setRotationType(RotationType::QUATERNION);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::QUATERNION);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromQuaternionToEuler()
@@ -161,12 +161,12 @@ void testModelSwitchFromQuaternionToEuler()
                 Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::QUATERNION);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to Euler
     model.setRotationType(RotationType::EULER);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::EULER);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelSwitchFromQuaternionToAxisAngle()
@@ -186,12 +186,12 @@ void testModelSwitchFromQuaternionToAxisAngle()
                 Vector4f());
     Matrix4 actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::QUATERNION);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
     // switch to AxisAngle
     model.setRotationType(RotationType::AXIS_ANGLE);
     actual = model.getRotationMatrix();
     assert(model.rotationType == RotationType::AXIS_ANGLE);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModelGetWorldTransform()
@@ -207,7 +207,7 @@ void testModelGetWorldTransform()
     Model model(2.456f, 3.23f, 5.55f, Vector4f(1.f, 2.f, 3.f, 1.f));
     Matrix4 actual = model.getWorldMatrix();
 
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testModel()

--- a/src/test/testParser.cpp
+++ b/src/test/testParser.cpp
@@ -75,9 +75,9 @@ void testParseScene()
         3, 3, 3,  4, 4, 4,  5, 5, 5
     };
 
-    ASSERT_VECTOR4F_ARRAY(vertices, expectedVertices);
-    ASSERT_VECTOR4F_ARRAY(normals, expectedNormals);
-    ASSERT_VECTOR4F_ARRAY(textureCoords, expectedTextureCoords);
+    ASSERT_VALUE_ARRAY(Vector4f, vertices, expectedVertices);
+    ASSERT_VALUE_ARRAY(Vector4f, normals, expectedNormals);
+    ASSERT_VALUE_ARRAY(Vector4f, textureCoords, expectedTextureCoords);
     ASSERT_VALUE_ARRAY(int, vertexIndices, expectedVertexIndices);
     ASSERT_VALUE_ARRAY(int, textureIndices, expectedTextureIndices);
     ASSERT_VALUE_ARRAY(int, normalIndices, expectedNormalIndices);

--- a/src/test/testQuaternion.cpp
+++ b/src/test/testQuaternion.cpp
@@ -11,7 +11,7 @@ void testQuaternionMultiplication()
     Quaternion q2{2.f, 6.5f, 2.3f, 7.4f};
     Quaternion expected{-251.2f, 196.6f, 76.4f, 58.2f};
     Quaternion actual = q1 * q2;
-    ASSERT_QUATERNION(actual, expected);
+    ASSERT_VALUE(Quaternion, actual, expected);
 }
 
 void testQuaternionMultiplication2()
@@ -21,7 +21,7 @@ void testQuaternionMultiplication2()
     Quaternion q2{0.f, 6.5f, 2.3f, 7.4f};
     Quaternion expected{-277.2f, 166.6f, 42.4f, 20.2f};
     Quaternion actual = q1 * q2;
-    ASSERT_QUATERNION(actual, expected);
+    ASSERT_VALUE(Quaternion, actual, expected);
 }
 
 void testQuaternionConjugate()
@@ -29,7 +29,7 @@ void testQuaternionConjugate()
     Quaternion q1{13.f, 15.f, 17.f, 19.f};
     Quaternion expected{13.f, -15.f, -17.f, -19.f};
     Quaternion actual = q1.conjugate();
-    ASSERT_QUATERNION(actual, expected);
+    ASSERT_VALUE(Quaternion, actual, expected);
 }
 
 void testQuaternionInverse()
@@ -37,7 +37,7 @@ void testQuaternionInverse()
     Quaternion q1{13.f, 15.f, 17.f, 19.f};
     Quaternion expected{0.012f, -0.014f, -0.016f, -0.018f};
     Quaternion actual = q1.inverse();
-    ASSERT_QUATERNION(actual, expected);
+    ASSERT_VALUE(Quaternion, actual, expected);
 }
 
 void testQuaternionMagnitudeSquared()
@@ -62,7 +62,7 @@ void testQuaternionNormalize()
     Quaternion q1{13.f, 15.f, 17.f, 19.f};
     Quaternion q2{13.f/magnitude, 15.f/magnitude, 17.f/magnitude, 19.f/magnitude};
     q1.normalize();
-    ASSERT_QUATERNION(q1, q2);
+    ASSERT_VALUE(Quaternion, q1, q2);
 }
 
 void testQuaternionToMatrix()
@@ -77,7 +77,7 @@ void testQuaternionToMatrix()
     Quaternion q1{13.f, 15.f, 17.f, 19.f};
     q1.normalize();
     Matrix4 actual = q1.toMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testQuaternion()

--- a/src/test/testRotation.cpp
+++ b/src/test/testRotation.cpp
@@ -19,7 +19,7 @@ void testAxisAngleRotation()
     Matrix4 expected(rawMat);
     AxisAngleRotation rotation(3.80020f, Vector4f(0.16825f, -0.31551f, -0.93388f, 1.f));
     Matrix4 actual = rotation.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testAxisAngleUpdateFromEuler()
@@ -36,7 +36,7 @@ void testAxisAngleUpdateFromEuler()
     }};
     Matrix4 expected(rawMat);
     Matrix4 actual = axisAngle.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testAxisAngleUpdateFromQuaternion()
@@ -53,7 +53,7 @@ void testAxisAngleUpdateFromQuaternion()
     }};
     Matrix4 expected(rawMat);
     Matrix4 actual = axisAngle.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testAxisAngleUpdateFromQuaternionWhenSinCloseToZero()
@@ -70,7 +70,7 @@ void testAxisAngleUpdateFromQuaternionWhenSinCloseToZero()
     }};
     Matrix4 expected(rawMat);
     Matrix4 actual = axisAngle.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 ////////////////////////////
@@ -88,7 +88,7 @@ void testQuaternionRotation()
     Matrix4 expected(rawMat);
     QuaternionRotation rotation(3.80018f, 0.15921f / 0.9462f, -0.29856f / 0.9462f, -0.88370f / 0.9462f);
     Matrix4 actual = rotation.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testQuaternionUpdateFromEuler()
@@ -104,7 +104,7 @@ void testQuaternionUpdateFromEuler()
     QuaternionRotation quaternion(0.f, 0.f, 0.f, 0.f);
     quaternion.updateFromEuler(&euler);
     Matrix4 actual = quaternion.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testQuaternionUpdateFromAxisAngle()
@@ -120,7 +120,7 @@ void testQuaternionUpdateFromAxisAngle()
     QuaternionRotation quaternion(0.f, 0.f, 0.f, 0.f);
     quaternion.updateFromAxisAngle(&axisAngle);
     Matrix4 actual = quaternion.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 ////////////////////////////
@@ -138,7 +138,7 @@ void testEulerRotation()
     Matrix4 expected(rawMat);
     EulerRotation rotation(2.456f, 3.23f, 5.55f);
     Matrix4 actual = rotation.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testEulerUpdateFromAxisAngle()
@@ -154,7 +154,7 @@ void testEulerUpdateFromAxisAngle()
     EulerRotation euler(0.f, 0.f, 0.f);
     euler.updateFromAxisAngle(&axisAngle);
     Matrix4 actual = euler.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testEulerUpdateFromQuaternion()
@@ -170,7 +170,7 @@ void testEulerUpdateFromQuaternion()
     EulerRotation euler(0.f, 0.f, 0.f);
     euler.updateFromQuaternion(&quaternion);
     Matrix4 actual = euler.getRotationMatrix();
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testRotation()

--- a/src/test/testSolver.cpp
+++ b/src/test/testSolver.cpp
@@ -74,7 +74,7 @@ void testSolverSolve()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = Solver::solve(actual);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testSolverSolve2() 
@@ -94,7 +94,7 @@ void testSolverSolve2()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = Solver::solve(actual);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testSolverSolve3() 
@@ -114,7 +114,7 @@ void testSolverSolve3()
     Matrix4 actual(actualArray);
     Matrix4 expected(expectedArray);
     actual = Solver::solve(actual);
-    ASSERT_MATRIX4(actual, expected);
+    ASSERT_VALUE(Matrix4, actual, expected);
 }
 
 void testSolver() 

--- a/src/test/testUtils.cpp
+++ b/src/test/testUtils.cpp
@@ -20,41 +20,6 @@ TestTimer::~TestTimer()
     std::cout << this->name << std::endl;;
 }
 
-void _ASSERT_VECTOR4F(Vector4f actual, Vector4f expected, const char* fileName, int lineNumber) 
-{
-    _ASSERT_VALUE<float>(actual.x, expected.x, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.y, expected.y, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.z, expected.z, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.w, expected.w, "", fileName, lineNumber);
-}
-
-void _ASSERT_VECTOR4I(Vector4i actual, Vector4i expected, const char* fileName, int lineNumber)
-{
-    _ASSERT_VALUE<int>(actual.x, expected.x, "" ,fileName, lineNumber);
-    _ASSERT_VALUE<int>(actual.y, expected.y, "" ,fileName, lineNumber);
-    _ASSERT_VALUE<int>(actual.z, expected.z, "" ,fileName, lineNumber);
-    _ASSERT_VALUE<int>(actual.w, expected.w, "" ,fileName, lineNumber);
-}
-
-void _ASSERT_QUATERNION(Quaternion actual, Quaternion expected, const char* fileName, int lineNumber) 
-{
-    _ASSERT_VALUE<float>(actual.x, expected.x, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.y, expected.y, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.z, expected.z, "", fileName, lineNumber);
-    _ASSERT_VALUE<float>(actual.w, expected.w, "", fileName, lineNumber);
-}
-
-void _ASSERT_MATRIX4(Matrix4 actual, Matrix4 expected, const char* fileName, int lineNumber) 
-{
-    for (int i = 0; i < 4; i++ ) 
-    {
-        for (int j = 0; j < 4; j++) 
-        {
-            _ASSERT_VALUE<float>(actual.get(i, j), expected.get(i, j), "", fileName, lineNumber);
-        }
-    }
-}
-
 void _ASSERT_AUGMENTED_MATRIX(std::array<std::array<float, 8>, 4> actual,
                               std::array<std::array<float, 8>, 4> expected,
                               const char* fileName, int lineNumber) 
@@ -81,15 +46,5 @@ void _ASSERT_FRAMEBUFFER(FrameBuffer* actual, FrameBuffer* expected, uint8_t err
                 _ASSERT_VALUE<uint32_t>(actual->get(i, j), expected->get(i, j), "", fileName, lineNumber);
             }
         }
-    }
-}
-
-void _ASSERT_VECTOR4F_ARRAY(std::vector<Vector4f> actual, std::vector<Vector4f> expected, 
-                            const char* fileName, int lineNumber)
-{
-    _ASSERT_VALUE<int>(actual.size(), expected.size(), "Size is different", fileName, lineNumber);
-    for (int i = 0; i < actual.size(); i++)
-    {
-        _ASSERT_VECTOR4F(actual[i], expected[i], fileName, lineNumber);
     }
 }

--- a/src/test/testUtils.hpp
+++ b/src/test/testUtils.hpp
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <iostream>
 #include <chrono>
+#include <type_traits>
 
 #include "../Vector.hpp"
 #include "../Matrix.hpp"
@@ -35,9 +36,23 @@ template<typename T>
 void _ASSERT_VALUE(T actual, T expected, std::string message, const char* fileName, int lineNumber)
 {
     bool result = true;
-    if (fabs(actual - expected) > 0.0005f) 
+    if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>)
     {
-        result = false;
+        if (fabs(actual - expected) > 0.0005f)
+        {
+            result = false;
+        }
+    }
+    else
+    {
+        if (actual != expected)
+        {
+            result = false;
+        }
+    }
+
+    if (!result)
+    {
         if (message != "")
         {
             std::cout << "Message: " << message << std::endl;
@@ -59,12 +74,6 @@ void _ASSERT_VALUE_ARRAY(std::vector<T> actual, std::vector<T> expected, const c
         _ASSERT_VALUE<T>(actual[i], expected[i], "", fileName, lineNumber);
     }
 }
-
-void _ASSERT_VECTOR4F(Vector4f actual, Vector4f expected, const char* fileName, int lineNumber);
-void _ASSERT_VECTOR4F_ARRAY(std::vector<Vector4f> actual, std::vector<Vector4f> expected, const char* fileName, int lineNumber);
-void _ASSERT_VECTOR4I(Vector4i actual, Vector4i expected, const char* fileName, int lineNumber);
-void _ASSERT_QUATERNION(Quaternion actual, Quaternion expected, const char* fileName, int lineNumber);
-void _ASSERT_MATRIX4(Matrix4 actual, Matrix4 expected, const char* fileName, int lineNumber);
 void _ASSERT_AUGMENTED_MATRIX(std::array<std::array<float, 8>, 4> actual, std::array<std::array<float, 8>, 4> expected, const char* fileName, int lineNumber);
 void _ASSERT_FRAMEBUFFER(FrameBuffer* actual, FrameBuffer* expected, uint8_t error, const char* fileName, int lineNumber);
 
@@ -72,10 +81,5 @@ void _ASSERT_FRAMEBUFFER(FrameBuffer* actual, FrameBuffer* expected, uint8_t err
 #define ASSERT_VALUE(type, actual, expected) _ASSERT_VALUE<type>(actual, expected, "", __FILE__, __LINE__);
 #define ASSERT_VALUE_ARRAY(type, actual, expected) _ASSERT_VALUE_ARRAY<type>(actual, expected, __FILE__, __LINE__);
 #define ASSERT_VALUE_WMSG(type, actual, expected, message) _ASSERT_VALUE<type>(actual, expected, message, __FILE__, __LINE__);
-#define ASSERT_VECTOR4F(actual, expected) _ASSERT_VECTOR4F(actual, expected, __FILE__, __LINE__);
-#define ASSERT_VECTOR4F_ARRAY(actual, expected) _ASSERT_VECTOR4F_ARRAY(actual, expected, __FILE__, __LINE__);
-#define ASSERT_VECTOR4I(actual, expected) _ASSERT_VECTOR4I(actual, expected, __FILE__, __LINE__);
-#define ASSERT_QUATERNION(actual, expected) _ASSERT_QUATERNION(actual, expected, __FILE__, __LINE__);
-#define ASSERT_MATRIX4(actual, expected) _ASSERT_MATRIX4(actual, expected, __FILE__, __LINE__);
 #define ASSERT_AUGMENTED_MATRIX(actual, expected) _ASSERT_AUGMENTED_MATRIX(actual, expected, __FILE__, __LINE__);
 #define ASSERT_FRAMEBUFFER(actual, expected) _ASSERT_FRAMEBUFFER(actual, expected, 1, __FILE__, __LINE__);

--- a/src/test/testVector.cpp
+++ b/src/test/testVector.cpp
@@ -9,7 +9,7 @@ void testVector4fAddition()
     Vector4f v2(1.f, 2.f, 3.f, 1.f);
     Vector4f expected(2.f, 4.f, 6.f, 1.f);
     Vector4f actual = v1 + v2;
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testVector4fSubtraction()
@@ -18,7 +18,7 @@ void testVector4fSubtraction()
     Vector4f v2(2.f, 3.5f, 14.2f, 1.f);
     Vector4f expected(-1.f, -1.5f, -11.2f, 1.f);
     Vector4f actual = v1 - v2;
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testVector4fNegation()
@@ -26,7 +26,7 @@ void testVector4fNegation()
     Vector4f v1(1.f, 2.f, 3.f, 1.f);
     Vector4f expected(-1.f, -2.f, -3.f, 1.f);
     Vector4f actual = -v1;
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testVector4fScale()
@@ -34,7 +34,7 @@ void testVector4fScale()
     Vector4f v1(1.f, 2.f, 3.f, 1.f);
     Vector4f expected(3.f, 6.f, 9.f, 1.f);
     Vector4f actual = v1 * 3.f;
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testVector4fDotProduct()
@@ -52,7 +52,7 @@ void testVector4fCrossProduct()
     Vector4f v2(2.f, 3.5f, 14.2f, 1.f);
     Vector4f expected(17.9f, -8.2f, -0.5f, 1.f);
     Vector4f actual = v1.cross(v2);
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 void testVector4fMagnitudeSquared()
@@ -75,7 +75,7 @@ void testVector4fNormalize()
     Vector4f actual(2.f, 3.f, 4.f, 1);
     actual.normalize();
     Vector4f expected(2.f/scale, 3.f/scale, 4.f/scale, 1.f);
-    ASSERT_VECTOR4F(actual, expected);
+    ASSERT_VALUE(Vector4f, actual, expected);
 }
 
 // int
@@ -86,7 +86,7 @@ void testVector4iAddition()
     Vector4i v2(1, 2, 3, 1);
     Vector4i expected(2, 4, 6, 1);
     Vector4i actual = v1 + v2;
-    ASSERT_VECTOR4I(actual, expected);
+    ASSERT_VALUE(Vector4i, actual, expected);
 }
 
 void testVector4iSubtraction()
@@ -95,7 +95,7 @@ void testVector4iSubtraction()
     Vector4i v2(2, 3, 14, 1);
     Vector4i expected(-1, -1, -11, 1);
     Vector4i actual = v1 - v2;
-    ASSERT_VECTOR4I(actual, expected);
+    ASSERT_VALUE(Vector4i, actual, expected);
 }
 
 void testVector4iNegation()
@@ -103,7 +103,7 @@ void testVector4iNegation()
     Vector4i v1(1, 2, 3, 1);
     Vector4i expected(-1, -2, -3, 1);
     Vector4i actual = -v1;
-    ASSERT_VECTOR4I(actual, expected);
+    ASSERT_VALUE(Vector4i, actual, expected);
 }
 
 void testVector4iScale()
@@ -111,7 +111,7 @@ void testVector4iScale()
     Vector4i v1(1, 2, 3, 1);
     Vector4i expected(3, 6, 9, 1);
     Vector4i actual = v1 * 3;
-    ASSERT_VECTOR4I(actual, expected);
+    ASSERT_VALUE(Vector4i, actual, expected);
 }
 
 void testVector4iDotProduct()
@@ -129,7 +129,7 @@ void testVector4iCrossProduct()
     Vector4i v2(2, 3, 14, 1);
     Vector4i expected(19, -8, -1, 1);
     Vector4i actual = v1.cross(v2);
-    ASSERT_VECTOR4I(actual, expected);
+    ASSERT_VALUE(Vector4i, actual, expected);
 }
 
 void testVector4iMagnitudeSquared()


### PR DESCRIPTION
Added `operator==`, `operator!=` and `operator<<` to the Vector/Matrix/Quaternion classes so they can use the `ASSERT_VALUE` function