### PR TITLE
Performance improvements rasterization

### DIFF
--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -78,48 +78,67 @@ void Rasterizer::drawTriangle(std::array<Vector4f, 3> vertices, Shader* shader, 
     int maxy = std::min(std::max({y0, y1, y2}), frameBuffer->height - 1);
 
     float area = 1.f / Rasterizer::edgeCheck(x0, y0, x1, y1, x2, y2);
-    for (int i = minx; i <= maxx; i++) 
-    {
-        for (int j = miny; j <= maxy; j++) 
-        {
 
+    int edgeA = Rasterizer::edgeCheck(x1, y1, x2, y2, minx, miny);
+    int edgeB = Rasterizer::edgeCheck(x2, y2, x0, y0, minx, miny);
+    int edgeC = Rasterizer::edgeCheck(x0, y0, x1, y1, minx, miny);
+    int initialEdgeA, initialEdgeB, initialEdgeC;
+    int dxA = x2 - x1;
+    int dxB = x0 - x2;
+    int dxC = x1 - x0;
+    int dyA = y2 - y1;
+    int dyB = y0 - y2;
+    int dyC = y1 - y0;
+
+    for (int y = miny; y <= maxy; y++)
+    {
+        initialEdgeA = edgeA;
+        initialEdgeB = edgeB;
+        initialEdgeC = edgeC;
+
+        for (int x = minx; x <= maxx; x++)
+        {
             // v0 maps to edge v1v2
             // v1 maps to edge v2v0
             // v2 maps to edge v0v1
-            std::array<float, 3> weights{ Rasterizer::edgeCheck(x1, y1, x2, y2, i, j),
-                                          Rasterizer::edgeCheck(x2, y2, x0, y0, i, j),
-                                          Rasterizer::edgeCheck(x0, y0, x1, y1, i, j)};
+            std::array<float, 3> weights{(float)initialEdgeA, (float)initialEdgeB, (float)initialEdgeC};
 
             // skip if we are not in triangle
             // CCW order= negative is inside / positive is outside (we are using this)
             // CW order = negative is outside/ positive is inside
-            if (weights[0] > 0 || weights[1] > 0 || weights[2] > 0)
+            if (weights[0] <= 0 && weights[1] <= 0 && weights[2] <= 0)
             {
-                continue;
+
+                // normalize weights
+                // w0 + w1 + w2 = 1
+                weights[0] *= area;
+                weights[1] *= area;
+                weights[2] *= area;
+
+                float depth = 1.f/(weights[0] * z0 + weights[1] * z1 + weights[2] * z2);
+
+                if (depth <= depthBuffer->get(x, y))
+                {
+
+                    // perspective correct texture mapping
+                    weights[0] = weights[0] * z0 * depth;
+                    weights[1] = weights[1] * z1 * depth;
+                    weights[2] = weights[2] * z2 * depth;
+
+                    depthBuffer->set(x, y, depth);
+                    const std::array<uint8_t, 3> color = shader->processFragment(weights);
+                    frameBuffer->set(x, y, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, color[0], color[1], color[2]));
+                }
             }
 
-            // normalize weights
-            // w0 + w1 + w2 = 1
-            weights[0] *= area;
-            weights[1] *= area;
-            weights[2] *= area;
-
-            float depth = 1.f/(weights[0] * z0 + weights[1] * z1 + weights[2] * z2);
-
-            if (depth > depthBuffer->get(i, j))
-            {
-                continue;
-            }
-
-            // perspective correct texture mapping
-            weights[0] = weights[0] * z0 * depth;
-            weights[1] = weights[1] * z1 * depth;
-            weights[2] = weights[2] * z2 * depth;
-
-            depthBuffer->set(i, j, depth);
-            const std::array<uint8_t, 3> color = shader->processFragment(weights);
-            frameBuffer->set(i, j, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, color[0], color[1], color[2]));
+            initialEdgeA += dyA;
+            initialEdgeB += dyB;
+            initialEdgeC += dyC;
         }
+
+        edgeA -= dxA;
+        edgeB -= dxB;
+        edgeC -= dxC;
     }
 }
 

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -72,21 +72,16 @@ void Rasterizer::drawTriangle(std::array<Vector4f, 3> vertices, Shader* shader, 
     float z0 = 1.f/vertices[0].w;
     float z1 = 1.f/vertices[1].w;
     float z2 = 1.f/vertices[2].w;
-    int minx = std::min({x0, x1, x2});
-    int maxx = std::max({x0, x1, x2});
-    int miny = std::min({y0, y1, y2});
-    int maxy = std::max({y0, y1, y2});
+    int minx = std::max(std::min({x0, x1, x2}), 0);
+    int maxx = std::min(std::max({x0, x1, x2}), frameBuffer->width - 1);
+    int miny = std::max(std::min({y0, y1, y2}), 0);
+    int maxy = std::min(std::max({y0, y1, y2}), frameBuffer->height - 1);
 
     float area = 1.f / Rasterizer::edgeCheck(x0, y0, x1, y1, x2, y2);
     for (int i = minx; i <= maxx; i++) 
     {
         for (int j = miny; j <= maxy; j++) 
         {
-            // discard fragments that are outside viewport
-            if (0 > i || i >= frameBuffer->width || 0 > j || j >= frameBuffer->height)
-            {
-                continue;
-            }
 
             // v0 maps to edge v1v2
             // v1 maps to edge v2v0

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -126,8 +126,8 @@ void Rasterizer::drawTriangle(std::array<Vector4f, 3> vertices, Shader* shader, 
                     weights[2] = weights[2] * z2 * depth;
 
                     depthBuffer->set(x, y, depth);
-                    const std::array<uint8_t, 3> color = shader->processFragment(weights);
-                    frameBuffer->set(x, y, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, color[0], color[1], color[2]));
+                    uint32_t color = shader->processFragment(weights);
+                    frameBuffer->set(x, y, SDL_MapRGB(Rasterizer::PIXEL_FORMAT, color >> 24, color >> 16, color >> 8));
                 }
             }
 

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -21,14 +21,8 @@ Vector4f BasicShader::processVertex(const Vector4f& vertex)
     return this->modelViewProjection * vertex;
 }
 
-const std::array<uint8_t, 3> BasicShader::processFragment(const std::array<float, 3>& weights) 
+uint32_t BasicShader::processFragment(const std::array<float, 3>& weights) 
 {
     
-    uint32_t color = TextureMapper::sample(this->diffuseTextureBuffer, 
-                                           this->diffuseTextureVertices, 
-                                           weights);
-    this->color[0] = color >> 24;
-    this->color[1] = color >> 16;
-    this->color[2] = color >> 8;
-    return this->color;
+    return TextureMapper::sample(this->diffuseTextureBuffer, this->diffuseTextureVertices, weights);
 }

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -24,5 +24,7 @@ Vector4f BasicShader::processVertex(const Vector4f& vertex)
 uint32_t BasicShader::processFragment(float w0, float w1, float w2) 
 {
     
-    return TextureMapper::sample(this->diffuseTextureBuffer, this->diffuseTextureVertices, w0, w1, w2);
+    return TextureMapper::sample(this->diffuseTextureBuffer, 
+                                 this->diffuseTextureV0, this->diffuseTextureV1, this->diffuseTextureV2, 
+                                 w0, w1, w2);
 }

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -21,8 +21,8 @@ Vector4f BasicShader::processVertex(const Vector4f& vertex)
     return this->modelViewProjection * vertex;
 }
 
-uint32_t BasicShader::processFragment(const std::array<float, 3>& weights) 
+uint32_t BasicShader::processFragment(float w0, float w1, float w2) 
 {
     
-    return TextureMapper::sample(this->diffuseTextureBuffer, this->diffuseTextureVertices, weights);
+    return TextureMapper::sample(this->diffuseTextureBuffer, this->diffuseTextureVertices, w0, w1, w2);
 }

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -11,7 +11,7 @@ class Shader
 {
     public:
         virtual Vector4f processVertex(const Vector4f& vertex) = 0;
-        virtual const std::array<uint8_t, 3> processFragment(const std::array<float, 3>& weights) = 0;
+        virtual uint32_t processFragment(const std::array<float, 3>& weights) = 0;
     private:
 };
 
@@ -22,7 +22,7 @@ class BasicShader: public Shader
         BasicShader(const Model* model,const Camera* camera);
         ~BasicShader();
         Vector4f processVertex(const Vector4f& vertex);
-        const std::array<uint8_t, 3> processFragment(const std::array<float, 3>& weights);
+        uint32_t processFragment(const std::array<float, 3>& weights);
 
         // per model data
         const TextureBuffer* diffuseTextureBuffer;

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -32,8 +32,9 @@ class BasicShader: public Shader
         Matrix4 projection;
 
         // per pixel data
-        std::array<Vector4f, 3> diffuseTextureVertices;
-        std::array<uint8_t, 3> color;
+        Vector4f diffuseTextureV0;
+        Vector4f diffuseTextureV1;
+        Vector4f diffuseTextureV2;
 
     private:
 };

--- a/src/Shader.hpp
+++ b/src/Shader.hpp
@@ -11,7 +11,7 @@ class Shader
 {
     public:
         virtual Vector4f processVertex(const Vector4f& vertex) = 0;
-        virtual uint32_t processFragment(const std::array<float, 3>& weights) = 0;
+        virtual uint32_t processFragment(float w0, float w1, float w2) = 0;
     private:
 };
 
@@ -22,7 +22,7 @@ class BasicShader: public Shader
         BasicShader(const Model* model,const Camera* camera);
         ~BasicShader();
         Vector4f processVertex(const Vector4f& vertex);
-        uint32_t processFragment(const std::array<float, 3>& weights);
+        uint32_t processFragment(float w0, float w1, float w2);
 
         // per model data
         const TextureBuffer* diffuseTextureBuffer;

--- a/src/SoftwareRenderer.cpp
+++ b/src/SoftwareRenderer.cpp
@@ -1,9 +1,10 @@
 #include "SoftwareRenderer.hpp"
 
-#include <iostream>
-
 #include "Buffer.hpp"
 #include "Shader.hpp"
+
+#include <iostream>
+#include <chrono>
 
 SoftwareRenderer::SoftwareRenderer(int width, int height, const char* fileName): input()
 {
@@ -48,11 +49,14 @@ void SoftwareRenderer::update()
 
 void SoftwareRenderer::draw()
 {
+    std::chrono::steady_clock::time_point before = std::chrono::steady_clock::now();
     const std::vector<Model*> models = this->scene->getModels();
     for (int i = 0; i < models.size(); i++)
     {
         this->drawModel(models[i]);
     }
+    std::chrono::steady_clock::time_point after = std::chrono::steady_clock::now();
+    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(after - before).count() << std::endl;
 }
 
 void SoftwareRenderer::clear()

--- a/src/SoftwareRenderer.cpp
+++ b/src/SoftwareRenderer.cpp
@@ -113,18 +113,17 @@ void SoftwareRenderer::drawModel(const Model* model)
         int indexT1 = diffuseTextureIndices[i + 1];
         int indexT2 = diffuseTextureIndices[i + 2];
 
-        shader.diffuseTextureVertices[0] = diffuseTextureCoords[indexT0];
-        shader.diffuseTextureVertices[1] = diffuseTextureCoords[indexT1];
-        shader.diffuseTextureVertices[2] = diffuseTextureCoords[indexT2];
+        shader.diffuseTextureV0 = diffuseTextureCoords[indexT0];
+        shader.diffuseTextureV1 = diffuseTextureCoords[indexT1];
+        shader.diffuseTextureV2 = diffuseTextureCoords[indexT2];
 
         #endif
 
         // vertex shader
-        std::array<Vector4f, 3> processedVertices{
-            shader.processVertex(vertices[indexV0]),
-            shader.processVertex(vertices[indexV1]),
-            shader.processVertex(vertices[indexV2])
-        };
+        std::array<Vector4f, 3> processedVertices;
+        processedVertices[0] = shader.processVertex(vertices[indexV0]);
+        processedVertices[1] = shader.processVertex(vertices[indexV1]);
+        processedVertices[2] = shader.processVertex(vertices[indexV2]);
 
         // perspective divide
         processedVertices[0] = processedVertices[0] / processedVertices[0].w;

--- a/src/TextureMapper.cpp
+++ b/src/TextureMapper.cpp
@@ -1,11 +1,11 @@
 #include "TextureMapper.hpp"
 
 uint32_t TextureMapper::sample(const TextureBuffer* textureBuffer, 
-                               const std::array<Vector4f, 3>& textureVertices,
+                               const Vector4f& t0, const Vector4f& t1, const Vector4f& t2,
                                float w0, float w1, float w2)
 {
-    float u = textureVertices[0].x * w0 + textureVertices[1].x * w1 + textureVertices[2].x * w2;
-    float v = textureVertices[0].y * w0 + textureVertices[1].y * w1 + textureVertices[2].y * w2;
+    float u = t0.x * w0 + t1.x * w1 + t2.x * w2;
+    float v = t0.y * w0 + t1.y * w1 + t2.y * w2;
     u = std::min(u, 1.f);
     v = std::min(v, 1.f);
     int width = u * textureBuffer->width - 1;

--- a/src/TextureMapper.cpp
+++ b/src/TextureMapper.cpp
@@ -2,10 +2,10 @@
 
 uint32_t TextureMapper::sample(const TextureBuffer* textureBuffer, 
                                const std::array<Vector4f, 3>& textureVertices,
-                               const std::array<float, 3>& weights)
+                               float w0, float w1, float w2)
 {
-    float u = textureVertices[0].x * weights[0] + textureVertices[1].x * weights[1] + textureVertices[2].x * weights[2];
-    float v = textureVertices[0].y * weights[0] + textureVertices[1].y * weights[1] + textureVertices[2].y * weights[2];
+    float u = textureVertices[0].x * w0 + textureVertices[1].x * w1 + textureVertices[2].x * w2;
+    float v = textureVertices[0].y * w0 + textureVertices[1].y * w1 + textureVertices[2].y * w2;
     u = std::min(u, 1.f);
     v = std::min(v, 1.f);
     int width = u * textureBuffer->width - 1;

--- a/src/TextureMapper.hpp
+++ b/src/TextureMapper.hpp
@@ -16,7 +16,7 @@ class TextureMapper
 {
     public:
         static uint32_t sample(const TextureBuffer* textureBuffer, 
-                               const std::array<Vector4f, 3>& textureVertices,
+                               const Vector4f& t0, const Vector4f& t1, const Vector4f& t2,
                                float w0, float w1, float w2);
     private:
 };

--- a/src/TextureMapper.hpp
+++ b/src/TextureMapper.hpp
@@ -17,6 +17,6 @@ class TextureMapper
     public:
         static uint32_t sample(const TextureBuffer* textureBuffer, 
                                const std::array<Vector4f, 3>& textureVertices,
-                               const std::array<float, 3>& weights);
+                               float w0, float w1, float w2);
     private:
 };


### PR DESCRIPTION
This PR updates the code with a few small things but the performance improved a lot. Rendering the initial scene with two cubes was taking `67ms`.

Change | Before | After
-|-|-|
Moved pixel discarding logic before the loop | 67ms | 64ms
Updated the rasterization loop to compute edge checks iteratively | 64ms | 60ms
Updated the fragment shader to return `uint32_t` instead of an array of `uint8_t` | 60ms | 50ms
Started passing barycentric coords as separate variables instead of an array | 50ms | 18ms
Started passing diffuse texture vertices as separate variables instead of an array | 18ms | 9ms

Currently the initial scene is being rendered in `9ms`. Getting close to the cubes slows down the rendering but that is expected as the rasterization area gets larger. Will deal with this in the future.